### PR TITLE
Add alternative akka http Java DSL, which wraps the scala DSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@ scalaLibTest/.gitignore
 scalaLibTest/.project
 scalaLibTest/.settings/
 scalaLibTest/target/
+akkaStreamsTest/.cache-main
+akkaStreamsTest/.classpath
+akkaStreamsTest/.gitignore
+akkaStreamsTest/.project
+akkaStreamsTest/.settings/
+tests/.cache-tests
+tests/bin/

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/AllDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/AllDirectives.scala
@@ -1,0 +1,12 @@
+package com.tradeshift.scalajapi.akka.route
+
+abstract class AllDirectives extends PathDirectives 
+                                with RouteDirectives 
+                                with ParameterDirectives 
+                                with BasicDirectives 
+                                with FutureDirectives 
+                                with MarshallingDirectives 
+                                with ExecutionDirectives 
+                                with MethodDirectives {
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/AllDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/AllDirectives.scala
@@ -6,7 +6,8 @@ abstract class AllDirectives extends PathDirectives
                                 with BasicDirectives 
                                 with FutureDirectives 
                                 with MarshallingDirectives 
-                                with ExecutionDirectives 
+                                with ExecutionDirectives
+                                with HeaderDirectives
                                 with MethodDirectives {
   
 }

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/BasicDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/BasicDirectives.scala
@@ -1,0 +1,10 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server.directives.{BasicDirectives => D}
+
+trait BasicDirectives {
+  def extract[T](f: java.util.function.Function[RequestContext,T], inner: java.util.function.Function[T,Route]): Route = {
+    val extractF = D.extract { ctx => f.apply(RequestContext(ctx)) }
+    ScalaRoute ( extractF { value => inner.apply(value).toScala } )
+  }
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Directives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Directives.scala
@@ -1,0 +1,5 @@
+package com.tradeshift.scalajapi.akka.route
+
+object Directives extends AllDirectives {
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ExceptionHandler.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ExceptionHandler.scala
@@ -1,0 +1,11 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server
+
+object ExceptionHandler {
+  def of(pf: PartialFunction[Throwable, Route]) = ExceptionHandler(server.ExceptionHandler(pf.andThen(_.toScala)))
+}
+
+case class ExceptionHandler(unwrap: server.ExceptionHandler) {
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ExecutionDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ExecutionDirectives.scala
@@ -1,0 +1,17 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server.directives.{ExecutionDirectives => D}
+
+trait ExecutionDirectives {
+  def handleExceptions(handler: ExceptionHandler, inner: java.util.function.Supplier[Route]) = ScalaRoute(
+    D.handleExceptions(handler.unwrap) {
+      inner.get.toScala
+    }
+  )
+  
+  def handleRejections(handler: RejectionHandler, inner: java.util.function.Supplier[Route]) = ScalaRoute(
+    D.handleRejections(handler.unwrap) {
+      inner.get.toScala
+    }
+  )
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/FutureDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/FutureDirectives.scala
@@ -1,0 +1,23 @@
+package com.tradeshift.scalajapi.akka.route
+
+import java.util.function.Supplier
+import java.util.function.{Function => JFunction}
+import com.tradeshift.scalajapi.concurrent.Future
+import akka.http.scaladsl.server.directives.{FutureDirectives => D}
+import com.tradeshift.scalajapi.collect.Try
+
+
+trait FutureDirectives {
+  def onComplete[T](f: Supplier[Future[T]], inner: JFunction[Try[T], Route]) = ScalaRoute (
+    D.onComplete(f.get.unwrap) { value => 
+      inner.apply(Try.wrap(value)).toScala 
+    }
+  )
+  
+  def onSuccess[T](f: Supplier[Future[T]], inner: JFunction[T, Route]) = ScalaRoute (
+    D.onSuccess(f.get.unwrap) { value => 
+      inner.apply(value).toScala 
+    }
+  )
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/HeaderDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/HeaderDirectives.scala
@@ -1,0 +1,65 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server.directives.{HeaderDirectives => D}
+import akka.http.javadsl.model.HttpHeader
+import java.util.{function => jf}
+import scala.reflect.ClassTag
+import akka.http.scaladsl.server.util.ClassMagnet
+import com.tradeshift.scalajapi.collect.Option
+
+/**
+ * (copy / refer to scala DSL doc here)
+ * 
+ * When implementing custom headers in Java, just extend akka.http.scaladsl.model.headers.CustomHeader,
+ * since the java API's CustomHeader class is pretty cumbersome to use.
+ */
+trait HeaderDirectives {
+  def headerValue[T](f: jf.Function[HttpHeader, Option[T]], inner: jf.Function[T, Route]) = ScalaRoute {
+    D.headerValue(h => f.apply(h).unwrap) { value => 
+      inner.apply(value).toScala
+    }
+  }
+  
+  def headerValuePF[T](pf: PartialFunction[HttpHeader, T], inner: jf.Function[T, Route]) = ScalaRoute {
+    D.headerValuePF(pf) { value =>
+      inner.apply(value).toScala
+    }
+  }
+  
+  def headerValueByName(headerName: String, inner: jf.Function[String, Route]) = ScalaRoute {
+    D.headerValueByName(headerName) { value =>
+      inner.apply(value).toScala
+    }
+  }
+  
+  def headerValueByType[T <: HttpHeader](t: Class[T], inner: jf.Function[T, Route]) = ScalaRoute {
+    D.headerValueByType(ClassMagnet(t).asInstanceOf[ClassMagnet[akka.http.scaladsl.model.HttpHeader]]) { value =>
+      inner.apply(value.asInstanceOf[T]).toScala
+    }
+  }
+  
+  def optionalHeaderValue[T](f: jf.Function[HttpHeader, Option[T]], inner: jf.Function[Option[T], Route]) = ScalaRoute {
+    D.optionalHeaderValue(h => f.apply(h).unwrap) { value => 
+      inner.apply(Option.wrap(value)).toScala
+    }
+  }
+  
+  def optionalHeaderValuePF[T](pf: PartialFunction[HttpHeader, T], inner: jf.Function[Option[T], Route]) = ScalaRoute {
+    D.optionalHeaderValuePF(pf) { value =>
+      inner.apply(Option.wrap(value)).toScala
+    }
+  }
+  
+  def optionalHeaderValueByName(headerName: String, inner: jf.Function[Option[String], Route]) = ScalaRoute {
+    D.optionalHeaderValueByName(headerName) { value =>
+      inner.apply(Option.wrap(value)).toScala
+    }
+  }
+  
+  def optionalHeaderValueByType[T <: HttpHeader](t: Class[T], inner: jf.Function[Option[T], Route]) = ScalaRoute {
+    D.optionalHeaderValueByType(ClassMagnet(t).asInstanceOf[ClassMagnet[akka.http.scaladsl.model.HttpHeader]]) { value =>
+      inner.apply(value.asInstanceOf[Option[T]]).toScala
+    }
+  }
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Marshaller.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Marshaller.scala
@@ -1,0 +1,95 @@
+package com.tradeshift.scalajapi.akka.route
+
+import java.util.function
+import akka.http.scaladsl.marshalling
+import scala.concurrent.ExecutionContext
+import akka.http.javadsl.model.ContentType
+import akka.http.scaladsl
+import akka.http.javadsl.model.HttpEntity
+import akka.http.scaladsl.marshalling.MediaTypeOverrider
+import akka.http.scaladsl.marshalling._
+import akka.http.javadsl.model.HttpResponse
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.RequestEntity
+import akka.util.ByteString
+import akka.http.scaladsl.model.FormData
+
+object Marshaller {
+  def wrap[A,B](scalaMarshaller: marshalling.Marshaller[A,B]) = Marshaller()(scalaMarshaller)
+  
+  /** 
+   * Safe downcasting of the output type of the marshaller to a superclass. 
+   *  
+   * Marshaller is covariant in B, i.e. if B2 is a subclass of B1, 
+   * then Marshaller[X,B2] is OK to use where Marshaller[X,B1] is expected. 
+   */
+  def downcast[A, B1, B2 <: B1](m: Marshaller[A,B2]): Marshaller[A,B1] = m.asInstanceOf[Marshaller[A,B1]]
+
+  /** 
+   * Safe downcasting of the output type of the marshaller to a superclass. 
+   *  
+   * Marshaller is covariant in B, i.e. if B2 is a subclass of B1, 
+   * then Marshaller[X,B2] is OK to use where Marshaller[X,B1] is expected. 
+   */
+  def downcast[A, B1, B2 <: B1](m: Marshaller[A,B2], target: Class[B1]): Marshaller[A,B1] = m.asInstanceOf[Marshaller[A,B1]]
+  
+  def stringToEntity: Marshaller[String,RequestEntity] = wrap(marshalling.Marshaller.StringMarshaller)
+
+  def byteArrayToEntity: Marshaller[Array[Byte],RequestEntity] = wrap(marshalling.Marshaller.ByteArrayMarshaller)
+
+  def charArrayToEntity: Marshaller[Array[Char],RequestEntity] = wrap(marshalling.Marshaller.CharArrayMarshaller)
+  
+  def byteStringToEntity: Marshaller[ByteString,RequestEntity] = wrap(marshalling.Marshaller.ByteStringMarshaller)
+  
+  def fromDataToEntity: Marshaller[FormData,RequestEntity] = wrap(marshalling.Marshaller.FormDataMarshaller)
+  
+  def wrapEntity[A,C](m: Marshaller[A,_ <: RequestEntity], contentType: ContentType, f:function.BiFunction[ExecutionContext,C,A]): Marshaller[C,RequestEntity] = {
+    val scalaMarshaller = toScala(downcast(m, classOf[RequestEntity]).unwrap)
+    wrap(scalaMarshaller.wrapWithEC(contentType) { ctx => c:C => f(ctx,c) } ) 
+  }
+
+  def wrapEntity[A,C](m: Marshaller[A,_ <: RequestEntity], contentType: ContentType, f:function.Function[C,A]): Marshaller[C,RequestEntity] = {
+    val scalaMarshaller = toScala(downcast(m, classOf[RequestEntity]).unwrap)
+    wrap(scalaMarshaller.wrap(contentType)(f.apply)) 
+  }
+
+  def wrapResponse[A,C](m: Marshaller[A,HttpResponse], contentType: ContentType, f:function.BiFunction[ExecutionContext,C,A]): Marshaller[C,HttpResponse] = {
+    wrap(toScala(m.unwrap).wrapWithEC(contentType) { ctx => c:C => f(ctx,c) }) 
+  }
+  
+  def wrapResponse[A,C](m: Marshaller[A,HttpResponse], contentType: ContentType, f:function.Function[C,A]): Marshaller[C,HttpResponse] = {
+    wrap(toScala(m.unwrap).wrap(contentType)(f.apply)) 
+  }
+  
+  def wrapRequest[A,C](m: Marshaller[A,HttpRequest], contentType: ContentType, f:function.BiFunction[ExecutionContext,C,A]): Marshaller[C,HttpRequest] = {
+    wrap(toScala(m.unwrap).wrapWithEC(contentType) { ctx => c:C => f(ctx,c) }) 
+  }
+  
+  def wrapRequest[A,C](m: Marshaller[A,HttpRequest], contentType: ContentType, f:function.Function[C,A]): Marshaller[C,HttpRequest] = {
+    wrap(toScala(m.unwrap).wrap(contentType)(f.apply)) 
+  }
+  
+  def entityToResponse[A](m: Marshaller[A,_ <: RequestEntity]): Marshaller[A,HttpResponse] = {
+    wrap(marshalling.Marshaller.fromToEntityMarshaller[A]()(m.unwrap))
+  }
+  
+  def oneOf[A, B] (m1: Marshaller[A, B], m2: Marshaller[A, B]): Marshaller[A, B] = {
+    wrap(marshalling.Marshaller.oneOf(m1.unwrap, m2.unwrap))
+  }
+  
+  def oneOf[A, B] (m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B]): Marshaller[A, B] = {
+    wrap(marshalling.Marshaller.oneOf(m1.unwrap, m2.unwrap, m3.unwrap))
+  }
+  
+  def oneOf[A, B] (m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B], m4: Marshaller[A, B]): Marshaller[A, B] = {
+    wrap(marshalling.Marshaller.oneOf(m1.unwrap, m2.unwrap, m3.unwrap, m4.unwrap))
+  }
+
+  def oneOf[A, B] (m1: Marshaller[A, B], m2: Marshaller[A, B], m3: Marshaller[A, B], m4: Marshaller[A, B], m5: Marshaller[A, B]): Marshaller[A, B] = {
+    wrap(marshalling.Marshaller.oneOf(m1.unwrap, m2.unwrap, m3.unwrap, m4.unwrap, m5.unwrap))
+  }
+}
+
+case class Marshaller[A,B] private (implicit val unwrap: marshalling.Marshaller[A,B]) {
+  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/MarshallingDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/MarshallingDirectives.scala
@@ -1,0 +1,26 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.javadsl.model.HttpRequest
+import akka.http.scaladsl.server.directives.{MarshallingDirectives => D}
+import akka.http.javadsl.model.HttpEntity
+
+trait MarshallingDirectives {
+  def entityAs[T](unmarshaller: Unmarshaller[_ >: HttpRequest,T], 
+                  inner: java.util.function.Function[T,Route]): Route = {
+    ScalaRoute(
+      D.entity(unmarshaller.unwrap) { value => 
+        inner.apply(value).toScala
+      }
+    )    
+  }
+  
+  def entityAs[T](t: Class[T], 
+                  unmarshaller: Unmarshaller[_ >: HttpRequest,_ <: T], 
+                  inner: java.util.function.Function[T,Route]): Route = {
+    ScalaRoute(
+      D.entity(unmarshaller.unwrap) { value => 
+        inner.apply(value).toScala
+      }
+    )
+  }
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/MethodDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/MethodDirectives.scala
@@ -1,0 +1,48 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server.directives.{MethodDirectives => D}
+import java.util.function
+import akka.http.javadsl.model.HttpMethod
+import akka.http.scaladsl
+
+trait MethodDirectives {
+  def delete(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.delete { inner.get.toScala }
+  )
+  
+  def get(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.get { inner.get.toScala }
+  )
+  
+  def head(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.head { inner.get.toScala }
+  )
+  
+  def options(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.options { inner.get.toScala }
+  )
+  
+  def patch(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.patch { inner.get.toScala }
+  )
+  
+  def post(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.post { inner.get.toScala }
+  )
+  
+  def put(inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.put { inner.get.toScala }
+  )
+  
+  def extractMethod(inner: function.Function[HttpMethod,Route]) = ScalaRoute (
+    D.extractMethod { m =>
+      inner.apply(m).toScala
+    }
+  )
+  
+  def method(method: HttpMethod, inner: function.Supplier[Route]): Route = ScalaRoute(
+    D.method(method) { 
+      inner.get.toScala 
+    }
+  )
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ParameterDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ParameterDirectives.scala
@@ -1,0 +1,55 @@
+package com.tradeshift.scalajapi.akka.route
+
+import com.tradeshift.scalajapi.collect.Option
+import com.tradeshift.scalajapi.collect.Seq
+import akka.http.scaladsl.server.directives.{ParameterDirectives => D}
+import akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers._
+import akka.http.scaladsl.server.directives.ParameterDirectives._
+import akka.http.scaladsl.common.ToNameReceptacleEnhancements.string2NR
+
+trait ParameterDirectives {
+  def param(name: String, inner: java.util.function.Function[String,Route]): Route = ScalaRoute(
+    D.parameter(name) { value =>
+      inner.apply(value).toScala
+    }
+  )
+  
+  def paramOption(name: String, inner: java.util.function.Function[Option[String],Route]): Route = ScalaRoute(
+    D.parameter(name.?) { value =>
+      inner.apply(Option.wrap(value)).toScala
+    }
+  )
+    
+  def paramSeq(name: String, inner: java.util.function.Function[Seq[String],Route]): Route = ScalaRoute(
+    D.parameter(string2NR(name).*) { values =>
+      inner.apply(Seq.wrap(values.toVector)).toScala
+    }
+  )
+  
+  def param[T](t:Unmarshaller[String,T], name: String, inner: java.util.function.Function[T,Route]): Route = {
+    import t.unwrap
+    ScalaRoute(
+      D.parameter(name.as[T]) { value =>
+        inner.apply(value).toScala
+      }
+    )
+  }
+  
+  def paramOption[T](t:Unmarshaller[String,T], name: String, inner: java.util.function.Function[Option[T],Route]): Route = {
+    import t.unwrap
+    ScalaRoute(
+      D.parameter(name.as[T].?) { value =>
+        inner.apply(Option.wrap(value)).toScala
+      }
+    )
+  }
+  
+  def paramSeq[T](t:Unmarshaller[String,T], name: String, inner: java.util.function.Function[Seq[T],Route]): Route = {
+    import t.unwrap
+    ScalaRoute(
+      D.parameter(name.as[T].?) { values =>
+        inner.apply(Seq.wrap(values.toVector)).toScala
+      }
+    )
+  }  
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/PathDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/PathDirectives.scala
@@ -1,0 +1,42 @@
+package com.tradeshift.scalajapi.akka.route
+
+import java.util.UUID
+import akka.http.scaladsl.server.directives.{PathDirectives => PD}
+import akka.http.scaladsl.server.PathMatchers
+import java.util.function.Supplier
+import scala.util.Success
+import scala.util.Failure
+import akka.http.scaladsl.server.ValidationRejection
+
+trait PathDirectives {
+  def path(element: String, inner: Supplier[Route]): Route = ScalaRoute(
+    PD.pathPrefix(element) {
+      inner.get.toScala
+    }
+  )
+
+  def path(inner: java.util.function.Function[String,Route]): Route = ScalaRoute(
+    PD.pathPrefix(PathMatchers.Segment) { element => 
+      inner.apply(element).toScala
+    }
+  )
+  
+  def path[T](t: Unmarshaller[String,T], inner: java.util.function.Function[T,Route]): Route = {
+    import akka.http.scaladsl.server.Directives._
+    import scala.concurrent.ExecutionContext.Implicits.global
+    
+    ScalaRoute(
+      PD.pathPrefix(PathMatchers.Segment) { element =>
+        onComplete(t.unwrap.apply(element)) {
+          case Success(value) =>
+            inner.apply(value).toScala
+          case Failure(x:IllegalArgumentException) =>
+            reject(ValidationRejection("not a valid path at this location (" + element + "): " + x.getMessage, Some(x)))
+          case Failure(x) =>
+            failWith(x)
+        }
+      }
+    )
+  }
+}
+

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RejectionHandler.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RejectionHandler.scala
@@ -1,0 +1,33 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server
+import java.util.function
+import akka.http.scaladsl.server.Rejection
+import scala.reflect.ClassTag
+import com.tradeshift.scalajapi.collect.Seq
+
+object RejectionHandler {
+  def newBuilder = new RejectionHandlerBuilder(server.RejectionHandler.newBuilder)
+  
+  def defaultHandler = RejectionHandler(server.RejectionHandler.default)
+}
+
+case class RejectionHandler(unwrap: server.RejectionHandler) {
+  def withFallback(fallback: RejectionHandler) = RejectionHandler(unwrap.withFallback(fallback.unwrap))
+  
+  def seal = RejectionHandler(unwrap.seal)
+}
+
+class RejectionHandlerBuilder(unwrap: server.RejectionHandler.Builder) {
+  def build = RejectionHandler(unwrap.result())
+  
+  def handle[T <: Rejection](t: Class[T], handler: function.Function[T, Route]): RejectionHandlerBuilder = {
+    unwrap.handle { case r if t.isInstance(r) => handler.apply(t.cast(r)).toScala }
+    this
+  }
+  
+  def handleAll[T <: Rejection](t: Class[T], handler: function.Function[Seq[T], Route]): RejectionHandlerBuilder = {
+    unwrap.handleAll { rejections:collection.immutable.Seq[T] => handler.apply(Seq.wrap(rejections)).toScala } (ClassTag(t))
+    this
+  }
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Rejections.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Rejections.scala
@@ -1,0 +1,84 @@
+package com.tradeshift.scalajapi.akka.route
+
+import com.tradeshift.scalajapi.collect.Option
+import com.tradeshift.scalajapi.collect.Set
+import com.tradeshift.scalajapi.collect.Seq
+import akka.http.scaladsl.server._
+import akka.http.javadsl.model.HttpMethod
+import akka.http.javadsl.model.MediaType
+import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.javadsl.model.headers.HttpEncoding
+import akka.http.javadsl.model.headers.ByteRange
+import akka.http.javadsl.model.ContentType
+import akka.http.javadsl.model.headers.HttpChallenge
+
+object Rejections {
+  def method(supported: HttpMethod) = MethodRejection(supported)
+  
+  def scheme(supported: String) = SchemeRejection(supported)
+  
+  def missingQueryParam(parameterName: String) = MissingQueryParamRejection(parameterName)
+  
+  def malformedQueryParam(parameterName: String, errorMsg: String) = 
+    MalformedQueryParamRejection(parameterName, errorMsg)
+  def malformedQueryParam(parameterName: String, errorMsg: String, cause: Option[Throwable]) = 
+    MalformedQueryParamRejection(parameterName, errorMsg, cause.unwrap)
+    
+  def missingFormField(fieldName: String) = MissingFormFieldRejection(fieldName)
+  
+  def malformedFormField(fieldName: String, errorMsg: String) = 
+    MalformedFormFieldRejection(fieldName, errorMsg)
+  def malformedFormField(fieldName: String, errorMsg: String, cause: Option[Throwable]) = 
+    MalformedFormFieldRejection(fieldName, errorMsg, cause.unwrap)
+  
+  def missingHeader(headerName: String) = MissingHeaderRejection(headerName)
+  
+  def malformedHeader(headerName: String, errorMsg: String) = 
+    MalformedHeaderRejection(headerName, errorMsg)
+  def malformedHeader(headerName: String, errorMsg: String, cause: Option[Throwable]) = 
+    MalformedHeaderRejection(headerName, errorMsg, cause.unwrap)
+  
+  def unsupportedRequestContentType(supported: Set[MediaType]) = 
+    UnsupportedRequestContentTypeRejection(supported.unwrap.map(ContentTypeRange(_)))
+    
+  def unsupportedRequestEncoding(supported: HttpEncoding) = UnsupportedRequestEncodingRejection(supported)
+    
+  def unsatisfiableRange(unsatisfiableRanges: Seq[ByteRange], actualEntityLength: Long) =
+    UnsatisfiableRangeRejection(unsatisfiableRanges.unwrap, actualEntityLength)
+    
+  def tooManyRanges(maxRanges: Int) = TooManyRangesRejection(maxRanges)
+  
+  def malformedRequestContent(message: String) = 
+    MalformedRequestContentRejection(message)
+  def malformedRequestContent(message: String, cause: Option[Throwable]) = 
+    MalformedRequestContentRejection(message, cause.unwrap)
+    
+  def requestEntityExpected = RequestEntityExpectedRejection
+  
+  def unacceptedResponseContentType(supported: Set[ContentType]) = 
+    UnacceptedResponseContentTypeRejection(supported.unwrap)
+  
+  def unacceptedResponseEncoding(supported: HttpEncoding) =
+    UnacceptedResponseEncodingRejection(supported)
+  def unacceptedResponseEncoding(supported: Set[HttpEncoding]) = 
+    UnacceptedResponseEncodingRejection(supported.unwrap)
+    
+  def authenticationCredentialsMissing(challenge: HttpChallenge) = 
+    AuthenticationFailedRejection(AuthenticationFailedRejection.CredentialsMissing, challenge)
+  def authenticationCredentialsRejected(challenge: HttpChallenge) = 
+    AuthenticationFailedRejection(AuthenticationFailedRejection.CredentialsRejected, challenge)
+
+  def authorizationFailed = AuthorizationFailedRejection
+  
+  def missingCookie(cookieName: String) = MissingCookieRejection(cookieName)
+  
+  def expectedWebsocketRequest = ExpectedWebsocketRequestRejection
+  
+  def validationRejection(message: String) = ValidationRejection(message)
+  def validationRejection(message: String, cause: Option[Throwable]) = ValidationRejection(message, cause.unwrap)
+  
+  def transformationRejection(f: java.util.function.Function[Seq[Rejection], Seq[Rejection]]) =
+    TransformationRejection(rejections => f.apply(Seq.wrap(rejections)).unwrap)
+  
+  def rejectionError(rejection: Rejection) = RejectionError(rejection)
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RequestContext.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RequestContext.scala
@@ -1,0 +1,7 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.javadsl.model.HttpRequest
+
+case class RequestContext(toScala: akka.http.scaladsl.server.RequestContext) {
+  def getRequest: HttpRequest = toScala.request
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Route.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Route.scala
@@ -1,0 +1,19 @@
+package com.tradeshift.scalajapi.akka.route
+
+import com.tradeshift.scalajapi.concurrent.Future
+import akka.stream.javadsl.Flow
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.HttpResponse
+import akka.http.scaladsl.server.{Route => SRoute}
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.http.scaladsl.server.Directives._
+import scala.annotation.varargs
+
+trait Route {
+  private[route] def toScala: SRoute
+  
+  def flow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, Unit]
+  def seal(system: ActorSystem, materializer: Materializer): Route
+  def orElse(alternative: Route): Route
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteDirectives.scala
@@ -1,0 +1,47 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.server.directives.{RouteDirectives => D}
+import akka.http.scaladsl.server.directives._
+import akka.http.javadsl.model.HttpResponse
+import akka.http.javadsl.model.StatusCode
+import akka.http.scaladsl.server.Rejection
+import scala.annotation.varargs
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+
+trait RouteDirectives {
+  /**
+   * Java-specific call added so you can chain together multiple alternate routes using comma,
+   * rather than having to explicitly call route1.orElse(route2).orElse(route3).
+   */
+  @varargs def route(alternatives: Route*) = ScalaRoute(
+    alternatives.map(_.toScala).reduce(_ ~ _)
+  )
+  
+  def reject: Route = ScalaRoute(
+    D.reject
+  )
+  
+  @varargs def rejectWith(rejections: Rejection*): Route = ScalaRoute(
+    D.reject(rejections: _*)
+  )
+  
+  def complete(body: String): Route = ScalaRoute(
+    D.complete(body)
+  )
+  
+  def complete(response: HttpResponse): Route = ScalaRoute(
+    D.complete(response: scaladsl.model.HttpResponse)
+  )
+  
+  def complete(status: StatusCode): Route = ScalaRoute(
+    D.complete(status: scaladsl.model.StatusCode)
+  )
+  
+  def complete[T](value: T, marshaller: Marshaller[T,HttpResponse]) = {
+    ScalaRoute(
+      D.complete(ToResponseMarshallable(value)(marshaller.unwrap))
+    )
+  }
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteDirectives.scala
@@ -9,6 +9,11 @@ import scala.annotation.varargs
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl
 import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.marshalling.Marshaller._
+import akka.http.javadsl.model.HttpHeader
+import akka.http.javadsl.model.RequestEntity
+import com.tradeshift.scalajapi.collect.Seq
 
 trait RouteDirectives {
   /**
@@ -39,9 +44,23 @@ trait RouteDirectives {
     D.complete(status: scaladsl.model.StatusCode)
   )
   
-  def complete[T](value: T, marshaller: Marshaller[T,HttpResponse]) = {
-    ScalaRoute(
-      D.complete(ToResponseMarshallable(value)(marshaller.unwrap))
-    )
+  def complete[T](value: T, marshaller: Marshaller[T,HttpResponse]) = ScalaRoute {
+    D.complete(ToResponseMarshallable(value)(marshaller.unwrap))
+  }
+  
+  def complete[T](status: StatusCode, headers: Seq[HttpHeader], value: T, marshaller: Marshaller[T,RequestEntity]) = ScalaRoute {
+    D.complete(ToResponseMarshallable(value)(fromToEntityMarshaller(status, headers.unwrap)(marshaller.unwrap)))
+  }
+  
+  def complete[T](status: StatusCode, value: T, marshaller: Marshaller[T,RequestEntity]) = ScalaRoute {
+    D.complete(ToResponseMarshallable(value)(fromToEntityMarshaller(status)(marshaller.unwrap)))
+  }
+  
+  def complete[T](headers: Seq[HttpHeader], value: T, marshaller: Marshaller[T,RequestEntity]) = ScalaRoute {
+    D.complete(ToResponseMarshallable(value)(fromToEntityMarshaller(headers = headers.unwrap)(marshaller.unwrap)))
+  }
+  
+  def completeOK[T](value: T, marshaller: Marshaller[T,RequestEntity]) = ScalaRoute {
+    D.complete(ToResponseMarshallable(value)(fromToEntityMarshaller()(marshaller.unwrap)))
   }
 }

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ScalaRoute.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/ScalaRoute.scala
@@ -1,0 +1,39 @@
+package com.tradeshift.scalajapi.akka.route
+
+import com.tradeshift.scalajapi.concurrent.Future
+import akka.http.scaladsl.server.Directive
+import akka.http.scaladsl.server.RouteConcatenation._
+import akka.stream.scaladsl.Flow
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.HttpResponse
+import akka.http.scaladsl.server.RoutingSettings
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.RoutingSetup
+import akka.stream.Materializer
+import akka.http.scaladsl.server.{Route => SRoute}
+import akka.http.scaladsl
+
+
+case class ScalaRoute(toScala: akka.http.scaladsl.server.Route) extends Route  {
+  override def flow(system: ActorSystem, materializer: Materializer) = scalaFlow(system,materializer).asJava
+  
+  private def scalaFlow(system: ActorSystem, materializer: Materializer): Flow[HttpRequest, HttpResponse, Unit] = {
+    implicit val s = system
+    implicit val m = materializer
+    SRoute.handlerFlow(toScala)
+  }
+  
+  override def orElse(alternative: Route): Route = alternative match {
+    case ScalaRoute(altRoute) =>
+      ScalaRoute(toScala ~ altRoute)
+      
+    case _ => throw new IllegalArgumentException("TODO wrap java route in scala")
+  }
+  
+  override def seal(system: ActorSystem, materializer: Materializer): Route = {
+    implicit val s = system
+    implicit val m = materializer
+
+    ScalaRoute(SRoute.seal(toScala))
+  }
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/StringUnmarshaller.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/StringUnmarshaller.scala
@@ -1,0 +1,32 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.unmarshalling.PredefinedFromStringUnmarshallers._
+import akka.http.scaladsl.unmarshalling
+import scala.concurrent.ExecutionContext
+import Unmarshaller.wrap
+import com.tradeshift.scalajapi.concurrent.Future
+
+object StringUnmarshaller {
+  def STRING = sync[String](java.util.function.Function.identity())
+  
+  def BYTE = wrap(byteFromStringUnmarshaller)
+  def SHORT = wrap(shortFromStringUnmarshaller)
+  def INT = wrap(intFromStringUnmarshaller)
+  def LONG = wrap(longFromStringUnmarshaller)
+  
+  def BYTE_HEX = wrap(HexByte)
+  def SHORT_HEX = wrap(HexShort)
+  def INT_HEX = wrap(HexInt)
+  def LONG_HEX = wrap(HexLong)
+  
+  def FLOAT = wrap(floatFromStringUnmarshaller)
+  def DOUBLE = wrap(doubleFromStringUnmarshaller)
+  
+  def BOOLEAN = wrap(booleanFromStringUnmarshaller)
+  
+  def UUID = wrap(unmarshalling.Unmarshaller.strict { s: String => java.util.UUID.fromString(s) })
+  
+  def async[B](f: java.util.function.BiFunction[String,ExecutionContext,Future[B]]): Unmarshaller[String,B] = Unmarshaller.async(f)
+  
+  def sync[B](f: java.util.function.Function[String,B]): Unmarshaller[String,B] = Unmarshaller.sync(f)
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Unmarshaller.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/Unmarshaller.scala
@@ -1,0 +1,107 @@
+package com.tradeshift.scalajapi.akka.route
+
+import akka.http.scaladsl.unmarshalling
+import scala.concurrent.ExecutionContext
+import com.tradeshift.scalajapi.concurrent.Future
+import com.tradeshift.scalajapi.collect.Seq
+import akka.stream.Materializer
+import scala.annotation.varargs
+import akka.http.javadsl.model.HttpEntity
+import akka.http.scaladsl.model.ContentTypeRange
+import akka.http.scaladsl
+import akka.http.javadsl.model.ContentType
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.RequestEntity
+import akka.http.javadsl.model.MediaType
+
+object Unmarshaller {
+  private implicit val _ = javaToScalaHttpEntity
+  
+  def wrap[A,B](scalaUnmarshaller: unmarshalling.Unmarshaller[A,B]) = Unmarshaller()(scalaUnmarshaller)
+
+  /**
+   * Creates an unmarshaller from an asynchronous Java function. The function should use the given execution
+   * context for its returned futures. 
+   */
+  def async[A,B](f: java.util.function.BiFunction[A,ExecutionContext,Future[B]]) = wrap(unmarshalling.Unmarshaller[A,B] {
+    ctx => a => f.apply(a, ctx).unwrap
+  })
+  
+  /**
+   * Creates an unmarshaller from a Java function.
+   */
+  def sync[A,B](f: java.util.function.Function[A,B]) = wrap(unmarshalling.Unmarshaller[A,B] {
+    ctx => a => scala.concurrent.Future.successful(f.apply(a))
+  })
+  
+  def entityToByteString(implicit materializer: Materializer) = 
+    wrapFromHttpEntity(unmarshalling.Unmarshaller.byteStringUnmarshaller)
+  
+  def entityToByteArray(implicit materializer: Materializer) = 
+    wrapFromHttpEntity(unmarshalling.Unmarshaller.byteArrayUnmarshaller)
+  
+  def entityToCharArray(implicit materializer: Materializer) = 
+    wrapFromHttpEntity(unmarshalling.Unmarshaller.charArrayUnmarshaller)
+  
+  def entityToString(implicit materializer: Materializer) = 
+    wrapFromHttpEntity(unmarshalling.Unmarshaller.stringUnmarshaller)
+  
+  def entityToUrlEncodedFormData(implicit materializer: Materializer) = 
+    wrapFromHttpEntity(unmarshalling.Unmarshaller.defaultUrlEncodedFormDataUnmarshaller)
+  
+  def requestToEntity = wrap(unmarshalling.Unmarshaller[HttpRequest,RequestEntity] {
+    ctx => request => scala.concurrent.Future.successful(request.entity())
+  })
+  
+  def forMediaType[B](t: MediaType, um:Unmarshaller[_ <: HttpEntity,B]): Unmarshaller[HttpEntity,B] = {
+    implicit val _ = javaToScalaHttpEntity
+    
+    wrap(toScala(um.unwrap).forContentTypes(t: scaladsl.model.MediaType))
+  }
+  
+  def forMediaTypes[B](types: Seq[MediaType], um:Unmarshaller[_ <: HttpEntity,B]): Unmarshaller[HttpEntity,B] = {
+    implicit val _ = javaToScalaHttpEntity
+
+    wrap(toScala(um.unwrap).forContentTypes(types.unwrap.map(ContentTypeRange(_)): _*))
+  }
+  
+  def firstOf[A, B] (u1: Unmarshaller[A, B], u2: Unmarshaller[A, B]): Unmarshaller[A, B] = {
+    wrap(unmarshalling.Unmarshaller.firstOf(u1.unwrap, u2.unwrap))
+  }
+  
+  def firstOf[A, B] (u1: Unmarshaller[A, B], u2: Unmarshaller[A, B], u3: Unmarshaller[A, B]): Unmarshaller[A, B] = {
+    wrap(unmarshalling.Unmarshaller.firstOf(u1.unwrap, u2.unwrap, u3.unwrap))
+  }
+  
+  def firstOf[A, B] (u1: Unmarshaller[A, B], u2: Unmarshaller[A, B], u3: Unmarshaller[A, B], u4: Unmarshaller[A, B]): Unmarshaller[A, B] = {
+    wrap(unmarshalling.Unmarshaller.firstOf(u1.unwrap, u2.unwrap, u3.unwrap, u4.unwrap))
+  }
+  
+  def firstOf[A, B] (u1: Unmarshaller[A, B], u2: Unmarshaller[A, B], u3: Unmarshaller[A, B], u4: Unmarshaller[A, B], u5: Unmarshaller[A, B]): Unmarshaller[A, B] = {
+    wrap(unmarshalling.Unmarshaller.firstOf(u1.unwrap, u2.unwrap, u3.unwrap, u4.unwrap, u5.unwrap))
+  }
+  
+  private def wrapFromHttpEntity[B](scalaUnmarshaller: unmarshalling.Unmarshaller[scaladsl.model.HttpEntity,B]) = {
+    wrap(scalaUnmarshaller: unmarshalling.Unmarshaller[HttpEntity,B])
+  }
+    
+}
+
+case class Unmarshaller[A,B] private (implicit val unwrap: unmarshalling.Unmarshaller[A,B]) {
+  import unmarshalling.Unmarshaller._
+  import Unmarshaller.wrap
+    
+  def map[C](f: java.util.function.Function[B,C]): Unmarshaller[A, C] = wrap(unwrap.map(f.apply))
+  
+  def flatMap[C](f: java.util.function.BiFunction[ExecutionContext,B,Future[C]]): Unmarshaller[A, C] = 
+    wrap(unwrap.flatMap { ctx => a => f.apply(ctx, a).unwrap })
+  
+  def flatMap[C](u: Unmarshaller[_ >: B,C]): Unmarshaller[A,C] =
+    wrap(unwrap.flatMap { ctx => a => u.unwrap.apply(a)(ctx) })
+    
+  def mapWithInput[C](f: java.util.function.BiFunction[A, B, C]): Unmarshaller[A, C] =
+    wrap(unwrap.mapWithInput { case (a,b) => f.apply(a, b) })
+
+  def flatMapWithInput[C](f: java.util.function.BiFunction[A, B, Future[C]]): Unmarshaller[A, C] =
+    wrap(unwrap.flatMapWithInput { case (a,b) => f.apply(a, b).unwrap })
+}

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
@@ -22,8 +22,10 @@ package object route {
     j.asInstanceOf[S]
   implicit def toScala[J,S](seq: Seq[J])(implicit c:TypeEquivalent[J,S]): Seq[S] = 
     seq.asInstanceOf[Seq[S]]
-  implicit def toScala[J,S](seq: Set[J])(implicit c:TypeEquivalent[J,S]): Set[S] = 
-    seq.asInstanceOf[Set[S]]
+  implicit def toScala[J,S](set: Set[J])(implicit c:TypeEquivalent[J,S]): Set[S] = 
+    set.asInstanceOf[Set[S]]
+  implicit def toScala[J,S](seq: collection.immutable.Seq[J])(implicit c:TypeEquivalent[J,S]): collection.immutable.Seq[S] = 
+    seq.asInstanceOf[collection.immutable.Seq[S]]
   implicit def toJava[JI,SI,O,M](flow: akka.stream.scaladsl.Flow[SI,O,M])(implicit c1:TypeEquivalent[JI,SI]) =
     flow.asInstanceOf[akka.stream.scaladsl.Flow[JI,O,M]]
   
@@ -44,6 +46,7 @@ package object route {
   implicit val javaToScalaHttpEncoding = TypeEquivalent[javadsl.model.headers.HttpEncoding, scaladsl.model.headers.HttpEncoding]
   implicit val javaToScalaByteRange = TypeEquivalent[javadsl.model.headers.ByteRange, scaladsl.model.headers.ByteRange]
   implicit val javaToScalaHttpChallenge = TypeEquivalent[javadsl.model.headers.HttpChallenge, scaladsl.model.headers.HttpChallenge]
+  implicit val javaToScalaHttpHeader = TypeEquivalent[javadsl.model.HttpHeader, scaladsl.model.HttpHeader]
   
   // not made implicit since it's a subtype
   val javaToScalaHttpEntity = TypeEquivalent[javadsl.model.HttpEntity, scaladsl.model.HttpEntity]

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
@@ -20,6 +20,10 @@ package object route {
     o.asInstanceOf[scaladsl.unmarshalling.Unmarshaller[S,T]]
   implicit def toScala[J,S](j: J)(implicit c:TypeEquivalent[J,S]): S = 
     j.asInstanceOf[S]
+  implicit def toScala[J,S](seq: Seq[J])(implicit c:TypeEquivalent[J,S]): Seq[S] = 
+    seq.asInstanceOf[Seq[S]]
+  implicit def toScala[J,S](seq: Set[J])(implicit c:TypeEquivalent[J,S]): Set[S] = 
+    seq.asInstanceOf[Set[S]]
   implicit def toJava[JI,SI,O,M](flow: akka.stream.scaladsl.Flow[SI,O,M])(implicit c1:TypeEquivalent[JI,SI]) =
     flow.asInstanceOf[akka.stream.scaladsl.Flow[JI,O,M]]
   
@@ -37,6 +41,9 @@ package object route {
   implicit val javaToScalaRequestEntity = TypeEquivalent[javadsl.model.RequestEntity, scaladsl.model.RequestEntity]
   implicit val javaToScalaHttpResponse = TypeEquivalent[javadsl.model.HttpResponse, scaladsl.model.HttpResponse]
   implicit val javaToScalaStatusCode = TypeEquivalent[javadsl.model.StatusCode, scaladsl.model.StatusCode]
+  implicit val javaToScalaHttpEncoding = TypeEquivalent[javadsl.model.headers.HttpEncoding, scaladsl.model.headers.HttpEncoding]
+  implicit val javaToScalaByteRange = TypeEquivalent[javadsl.model.headers.ByteRange, scaladsl.model.headers.ByteRange]
+  implicit val javaToScalaHttpChallenge = TypeEquivalent[javadsl.model.headers.HttpChallenge, scaladsl.model.headers.HttpChallenge]
   
   // not made implicit since it's a subtype
   val javaToScalaHttpEntity = TypeEquivalent[javadsl.model.HttpEntity, scaladsl.model.HttpEntity]

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/package.scala
@@ -1,0 +1,43 @@
+package com.tradeshift.scalajapi.akka
+
+import akka.http.javadsl
+import akka.http.scaladsl
+import scala.language.implicitConversions
+
+package object route {
+  // We define implicit conversions from the javadsl model objects to the scaladsl subclasses,
+  // for all types where there is only 1 valid direct subclass of the javadsl type
+  // (being the scaladsl one)
+  
+  // These are gathered here rather than doing explicit asInstanceOf throughout the code, in order
+  // to get predictable compile errors if this hierarchy might ever change.
+  
+  implicit def toScala[T,J,S](o: scaladsl.marshalling.Marshaller[T,J])(implicit c:TypeEquivalent[J,S]) = 
+    o.asInstanceOf[scaladsl.marshalling.Marshaller[T,S]]
+  implicit def toJava[J,S,T](o: scaladsl.unmarshalling.Unmarshaller[S,T])(implicit c:TypeEquivalent[J,S]) =
+    o.asInstanceOf[scaladsl.unmarshalling.Unmarshaller[J,T]]
+  implicit def toScala[J,S,T](o: scaladsl.unmarshalling.Unmarshaller[J,T])(implicit c:TypeEquivalent[J,S]) =
+    o.asInstanceOf[scaladsl.unmarshalling.Unmarshaller[S,T]]
+  implicit def toScala[J,S](j: J)(implicit c:TypeEquivalent[J,S]): S = 
+    j.asInstanceOf[S]
+  implicit def toJava[JI,SI,O,M](flow: akka.stream.scaladsl.Flow[SI,O,M])(implicit c1:TypeEquivalent[JI,SI]) =
+    flow.asInstanceOf[akka.stream.scaladsl.Flow[JI,O,M]]
+  
+  /**
+   * Marker class to indicate that either 
+   * - [J] has only one direct subclass, being [S]
+   * OR
+   * - all Java DSL subtypes of [J] have scala DSL subclasses that are also subclasses of [S] 
+   */
+  case class TypeEquivalent[-J, S]()
+  implicit val javaToScalaMediaType = TypeEquivalent[javadsl.model.MediaType, scaladsl.model.MediaType]
+  implicit val javaToScalaContentType = TypeEquivalent[javadsl.model.ContentType, scaladsl.model.ContentType]
+  implicit val javaToScalaHttpMethod = TypeEquivalent[javadsl.model.HttpMethod, scaladsl.model.HttpMethod]
+  implicit val javaToScalaHttpRequest = TypeEquivalent[javadsl.model.HttpRequest, scaladsl.model.HttpRequest]
+  implicit val javaToScalaRequestEntity = TypeEquivalent[javadsl.model.RequestEntity, scaladsl.model.RequestEntity]
+  implicit val javaToScalaHttpResponse = TypeEquivalent[javadsl.model.HttpResponse, scaladsl.model.HttpResponse]
+  implicit val javaToScalaStatusCode = TypeEquivalent[javadsl.model.StatusCode, scaladsl.model.StatusCode]
+  
+  // not made implicit since it's a subtype
+  val javaToScalaHttpEntity = TypeEquivalent[javadsl.model.HttpEntity, scaladsl.model.HttpEntity]
+}

--- a/akkaStreamsTest/build.sbt
+++ b/akkaStreamsTest/build.sbt
@@ -1,0 +1,12 @@
+name := "akkaStreamsTest"
+
+libraryDependencies ++= {
+  val akkaVersion = "2.4.0"
+  val akkaStreamVersion = "1.0"
+
+  Seq(
+    "com.typesafe.akka" %% "akka-actor" % akkaVersion,
+    "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
+    "com.typesafe.akka" %% "akka-http-testkit-experimental" % akkaStreamVersion
+  )
+}

--- a/akkaStreamsTest/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteTestKit.scala
+++ b/akkaStreamsTest/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteTestKit.scala
@@ -1,0 +1,61 @@
+package com.tradeshift.scalajapi.akka.route
+
+import com.tradeshift.scalajapi.collect.Seq
+import com.tradeshift.scalajapi.collect.Option
+import akka.http.scaladsl.testkit.RouteTest
+import akka.http.scaladsl.testkit.TestFrameworkInterface
+import akka.http.javadsl.model.HttpRequest
+import akka.http.javadsl.model.HttpEntityStrict
+import scala.concurrent.duration._
+import scala.concurrent.Await
+import akka.http.javadsl.model.HttpEntity
+import akka.http.javadsl.model.ChunkStreamPart
+import akka.http.javadsl.model.HttpHeader
+import scala.reflect.ClassTag
+import akka.http.scaladsl.server.Rejection
+import akka.http.javadsl.model.ContentType
+import akka.http.javadsl.model.MediaType
+import akka.http.javadsl.model.HttpResponse
+import akka.http.javadsl.model.ResponseEntity
+import akka.http.javadsl.model.HttpCharset
+import akka.http.javadsl.model.StatusCode
+
+class RouteTestKit {
+  private trait Runner {
+    def run(request: HttpRequest, route: Route, checks: => Unit)
+  }
+  
+  private val kit = new RouteTest with TestFrameworkInterface with Runner {
+    override def failTest(msg:String): Nothing = throw new AssertionError(msg)
+    
+    def run(request: HttpRequest, route: Route, checks: => Unit) {
+      request.asInstanceOf[akka.http.scaladsl.model.HttpRequest] ~> route.toScala ~> check {
+        checks
+      }
+    }
+  }
+  
+  implicit def system = kit.system
+  implicit def materializer = kit.materializer
+  
+  def on(request: HttpRequest, route: Route, checks: java.lang.Runnable) {
+    kit.run(request, route, checks.run())
+  }
+  
+  def onSealed(request: HttpRequest, route: Route, checks: java.lang.Runnable) {
+    kit.run(request, route.seal(system, materializer), checks.run())
+  }
+  
+  def handled:Boolean = kit.handled
+  def rejections:Seq[Rejection] = Seq.wrap(kit.rejections)
+  def response:HttpResponse = kit.response
+  def responseEntity:HttpEntity = kit.responseEntity
+  def chunks:Seq[ChunkStreamPart] = Seq.wrap(kit.chunks)
+  def contentType:ContentType = kit.contentType
+  def mediaType:MediaType = kit.mediaType
+  def charset:HttpCharset = kit.charset
+  def responseEntityStrict:HttpEntityStrict = Await.result(kit.response.entity.toStrict(3.seconds), 3.seconds)
+  def headers:Seq[HttpHeader] = Seq.wrap(kit.headers)
+  def header[T <: akka.http.scaladsl.model.HttpHeader](c:Class[T]):Option[T] = Option.wrap(kit.header[T](ClassTag(c)))
+  def status:StatusCode = kit.status
+}

--- a/akkaStreamsTest/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteTestKit.scala
+++ b/akkaStreamsTest/src/main/scala/com/tradeshift/scalajapi/akka/route/RouteTestKit.scala
@@ -86,6 +86,8 @@ class RouteTestKit {
   
   def handled:Boolean = kit.handled
   def rejections:Seq[Rejection] = Seq.wrap(kit.rejections)
+  def rejection:Rejection = kit.rejection
+  
   def response:HttpResponse = kit.response
   def responseEntity:HttpEntity = kit.responseEntity
   def chunks:Seq[ChunkStreamPart] = Seq.wrap(kit.chunks)
@@ -96,4 +98,22 @@ class RouteTestKit {
   def headers:Seq[HttpHeader] = Seq.wrap(kit.headers)
   def header[T <: akka.http.scaladsl.model.HttpHeader](c:Class[T]):Option[T] = Option.wrap(kit.header[T](ClassTag(c)))
   def status:StatusCode = kit.status
+  
+  // --- extra non-wrapped methods to make Java API just a little nicer ---
+  /** 
+   * Returns a single expected rejection, verifying that is indeed an instance of T.  
+   */
+  def rejection[T <: Rejection](t: Class[T]): T = {
+    val r = rejection
+    if (t.isInstance(r)) r.asInstanceOf[T] else kit.failTest("Expected a rejection of type %s but got %s".format(t.getSimpleName, r))
+  }
+  /**
+   * Returns whether the request was rejected by the route
+   */
+  def isRejected:Boolean = { kit.rejections; true }
+  /**
+   * Returns whether the request was rejected by the route as an empty rejection list
+   * (see http://doc.akka.io/docs/akka-stream-and-http-experimental/snapshot/scala/http/routing-dsl/rejections.html#Empty_Rejections
+   */
+  def isEmptyRejected: Boolean = rejections.isEmpty
 }

--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201511191609",
+    version := "0.1-201512031119",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201512031437",
+    version := "0.1-201512031534",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -13,11 +13,13 @@ object ScalaJApi extends Build {
     EclipseKeys.withSource := true
   )
 
-  lazy val akkaStreams = project.settings(commonSettings: _*)
-  
   lazy val scalaLib = project.settings(commonSettings: _*)
+  
+  lazy val akkaStreams = project.settings(commonSettings: _*).dependsOn(scalaLib)
+  
+  lazy val akkaStreamsTest = project.settings(commonSettings: _*).dependsOn(akkaStreams)
   
   lazy val scalaLibTest = project.settings(commonSettings: _*).dependsOn(scalaLib)
   
-  lazy val tests = project.settings(commonSettings: _*).dependsOn(scalaLib, akkaStreams)
+  lazy val tests = project.settings(commonSettings: _*).dependsOn(scalaLib, akkaStreams, akkaStreamsTest, scalaLibTest)
 }

--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201512031119",
+    version := "0.1-201512031437",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Either.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Either.scala
@@ -1,0 +1,81 @@
+package com.tradeshift.scalajapi.collect
+
+object Either {
+  def wrap[L,R](scalaEither: scala.util.Either[L,R]): Either[L,R] = Either(scalaEither)
+  
+  case class LeftProjection[L,R] private[collect] (unwrap: scala.util.Either.LeftProjection[L,R]) {
+    def e: Either[L,R] = Either.wrap(unwrap.e)
+    
+    def exists(p: java.util.function.Predicate[_ >: L]): Boolean = unwrap.exists(p.test)
+      
+    def filter[Y](p: java.util.function.Predicate[_ >: L]): Option[Either[L,Y]] = 
+      Option.wrap(unwrap.filter(p.test).map(Either.wrap))
+      
+    def flatMap[X](f: java.util.function.Function[_ >: L, Either[X, _ <: R]]): Either[X, R] =
+      wrap(unwrap.flatMap(l => f.apply(l).unwrap))
+    
+    def forall(p: java.util.function.Predicate[_ >: L]): Boolean = unwrap.forall(p.test)
+ 
+    def foreach(c: java.util.function.Consumer[_ >: L]): Unit = unwrap.foreach(c.accept)
+    
+    def get: L = unwrap.get
+    
+    def getOrElse(f: java.util.function.Supplier[_ <: L]): L = unwrap.getOrElse(f.get)
+    
+    def map[X](f: java.util.function.Function[_ >: L, X]): Either[X, R] = wrap(unwrap.map(f.apply))
+    
+    def toOption: Option[L] = Option.wrap(unwrap.toOption)
+    
+    def toSeq: Seq[L] = Seq.wrap(unwrap.toSeq.toVector)
+  }
+  
+  case class RightProjection[L,R] private[collect] (unwrap: scala.util.Either.RightProjection[L,R]) {
+    def e: Either[L,R] = Either.wrap(unwrap.e)
+    
+    def exists(p: java.util.function.Predicate[_ >: R]): Boolean = unwrap.exists(p.test)
+      
+    def filter[Y](p: java.util.function.Predicate[_ >: R]): Option[Either[Y,R]] = 
+      Option.wrap(unwrap.filter(p.test).map(Either.wrap))
+      
+    def flatMap[X](f: java.util.function.Function[_ >: R, Either[_ <: L, X]]): Either[L, X] =
+      wrap(unwrap.flatMap(l => f.apply(l).unwrap))
+    
+    def forall(p: java.util.function.Predicate[_ >: R]): Boolean = unwrap.forall(p.test)
+ 
+    def foreach(c: java.util.function.Consumer[_ >: R]): Unit = unwrap.foreach(c.accept)
+    
+    def get: R = unwrap.get
+    
+    def getOrElse(f: java.util.function.Supplier[_ <: R]): R = unwrap.getOrElse(f.get)
+    
+    def map[X](f: java.util.function.Function[_ >: R, X]): Either[L, X] = wrap(unwrap.map(f.apply))
+    
+    def toOption: Option[R] = Option.wrap(unwrap.toOption)
+    
+    def toSeq: Seq[R] = Seq.wrap(unwrap.toSeq.toVector)
+  }    
+}
+
+object Left {
+  def of[L,R](value: L): Either[L,R] = Either.wrap(scala.util.Left(value))
+}
+
+object Right {
+  def of[L,R](value: R): Either[L,R] = Either.wrap(scala.util.Right(value))  
+}
+
+case class Either[L,R] private (unwrap: scala.util.Either[L,R]) {
+  import Either._
+  
+  def isLeft: Boolean = unwrap.isLeft
+  def isRight: Boolean = unwrap.isRight
+  
+  def left: LeftProjection[L,R] = LeftProjection(unwrap.left)
+  def right: RightProjection[L,R] = RightProjection(unwrap.right)
+  
+  def fold[X](fa: java.util.function.Function[_ >: L,X], fb: java.util.function.Function[R,X]): X = 
+    unwrap.fold(fa.apply, fb.apply) 
+    
+  def swap: Either[R,L] = wrap(unwrap.swap)
+}
+

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
@@ -90,6 +90,12 @@ case class Map[K,V] private (val unwrap: immutable.Map[K,V]) extends java.lang.I
   
   def valuesToSeq: Seq[V] = Seq.wrap(unwrap.values.toVector)
   
+  def foreach(f: java.util.function.BiConsumer[K,V]) = unwrap.foreach { case (k,v) => f.accept(k,v) }
+  
+  def exists(p: java.util.function.BiPredicate[K,V]): Boolean = unwrap.exists { case (k,v) => p.test(k,v) }
+  
+  def forall(p: java.util.function.BiPredicate[K,V]): Boolean = unwrap.forall { case (k,v) => p.test(k,v) }
+  
   override def iterator: java.util.Iterator[(K,V)] = new java.util.Iterator[(K,V)] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
@@ -54,13 +54,13 @@ case class Option[T] private (val unwrap: scala.Option[T]) extends java.lang.Ite
   
   def get:T = unwrap.get
   
-  def getOrElse[T1 >: T](f: java.util.function.Supplier[T1]): T1 = unwrap.getOrElse(f.get())
+  def getOrElse(f: java.util.function.Supplier[_ <: T]): T = unwrap.getOrElse(f.get())
   
-  def orElse[T1 >: T](f: java.util.function.Supplier[Option[T1]]): Option[T1] = wrap(unwrap.orElse(f.get().unwrap))
+  def orElse(f: java.util.function.Supplier[Option[_ <: T]]): Option[T] = wrap(unwrap.orElse(f.get().unwrap))
   
   def orNull = getOrElse(null)
   
-  def filter(p: java.util.function.Predicate[T]): Option[T] = wrap(unwrap.filter(p.test))
+  def filter(p: java.util.function.Predicate[_ >: T]): Option[T] = wrap(unwrap.filter(p.test))
   
   def size:Int = unwrap.size
   
@@ -82,6 +82,12 @@ case class Option[T] private (val unwrap: scala.Option[T]) extends java.lang.Ite
           Spliterators.spliterator(iterator, size, Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
   
+  def foreach(f: java.util.function.Consumer[T]) = unwrap.foreach(f.accept)
+  
+  def exists(p: java.util.function.Predicate[T]): Boolean = unwrap.exists(p.test)
+
+  def forall(p: java.util.function.Predicate[T]): Boolean = unwrap.forall(p.test)
+
   override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
@@ -19,6 +19,14 @@ object Seq {
   def empty[T]: Seq[T] = wrap(immutable.Seq.empty)
   
   def of[T](t1: T): Seq[T] = wrap(immutable.Seq(t1))
+  def of[T](t1: T, t2:T): Seq[T] = wrap(immutable.Seq(t1,t2))
+  def of[T](t1: T, t2:T, t3:T): Seq[T] = wrap(immutable.Seq(t1,t2,t3))
+  def of[T](t1: T, t2:T, t3:T, t4:T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4,t5))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4,t5,t6))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4,t5,t6,t7))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4,t5,t6,t7,t8))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T, t9: T): Seq[T] = wrap(immutable.Seq(t1,t2,t3,t4,t5,t6,t7,t8,t9))
   
   def ofAll[T](items: java.lang.Iterable[T]): Seq[T] = wrap(items.asScala.toVector)
   
@@ -109,6 +117,12 @@ case class Seq[T] private (val unwrap: immutable.Seq[T]) extends java.lang.Itera
   def asStream: java.util.stream.Stream[T] = StreamSupport.stream(
           Spliterators.spliterator(iterator, size, Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
+  
+  def foreach(f: java.util.function.Consumer[T]) = unwrap.foreach(f.accept)
+
+  def exists(p: java.util.function.Predicate[T]): Boolean = unwrap.exists(p.test)
+
+  def forall(p: java.util.function.Predicate[T]): Boolean = unwrap.forall(p.test)
   
   override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
@@ -19,6 +19,15 @@ object Set {
   def empty[T]: Set[T] = wrap(immutable.Set.empty)
   
   def of[T](t1: T): Set[T] = wrap(immutable.Set(t1))
+  def of[T](t1: T, t2:T): Set[T] = wrap(immutable.Set(t1,t2))
+  def of[T](t1: T, t2:T, t3:T): Set[T] = wrap(immutable.Set(t1,t2,t3))
+  def of[T](t1: T, t2:T, t3:T, t4:T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4,t5))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4,t5,t6))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4,t5,t6,t7))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4,t5,t6,t7,t8))
+  def of[T](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T, t9: T): Set[T] = wrap(immutable.Set(t1,t2,t3,t4,t5,t6,t7,t8,t9))
+  
   
   def ofAll[T](items: java.lang.Iterable[T]): Set[T] = wrap(items.asScala.toSet)
   
@@ -65,6 +74,12 @@ case class Set[T] private (val unwrap: immutable.Set[T]) extends java.lang.Itera
   def asStream: java.util.stream.Stream[T] = StreamSupport.stream(
           Spliterators.spliterator(iterator, size, Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
+  
+  def foreach(f: java.util.function.Consumer[T]) = unwrap.foreach(f.accept)
+
+  def forall(p: java.util.function.Predicate[T]): Boolean = unwrap.forall(p.test)
+
+  def exists(p: java.util.function.Predicate[T]): Boolean = unwrap.exists(p.test)
   
   override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
@@ -19,6 +19,15 @@ object SortedSet {
   def empty[T <: Comparable[T]]: SortedSet[T] = wrap(immutable.SortedSet.empty)
   
   def of[T <: Comparable[T]](t1: T): SortedSet[T] = wrap(immutable.SortedSet(t1))
+  def of[T <: Comparable[T]](t1: T, t2:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T, t5:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4,t5))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4,t5,t6))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4,t5,t6,t7))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4,t5,t6,t7,t8))
+  def of[T <: Comparable[T]](t1: T, t2:T, t3:T, t4:T, t5:T, t6:T, t7:T, t8: T, t9: T): SortedSet[T] = wrap(immutable.SortedSet(t1,t2,t3,t4,t5,t6,t7,t8,t9))
+  
   
   def ofAll[T <: Comparable[T]](items: java.lang.Iterable[T]): SortedSet[T] = wrap(immutable.SortedSet.empty[T] ++ items.asScala)
   
@@ -71,6 +80,12 @@ case class SortedSet[T] private (val unwrap: immutable.SortedSet[T]) extends jav
   def asStream: java.util.stream.Stream[T] = StreamSupport.stream(
           Spliterators.spliterator(iterator, size, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
+  
+  def foreach(f: java.util.function.Consumer[T]) = unwrap.foreach(f.accept)
+  
+  def exists(p: java.util.function.Predicate[T]): Boolean = unwrap.exists(p.test)
+  
+  def forall(p: java.util.function.Predicate[T]): Boolean = unwrap.forall(p.test)
   
   override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Try.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Try.scala
@@ -1,0 +1,47 @@
+package com.tradeshift.scalajapi.collect
+
+import scala.util.{Try => STry}
+
+object Try {
+  def wrap[T](scalaTry: STry[T]): Try[T] = Try(scalaTry)
+  
+  def call[T](sup: java.util.function.Supplier[T]): Try[T] = wrap(STry { sup.get() })
+  
+  def failed(error: Throwable) = wrap(scala.util.Failure(error))
+  
+  def success[T](value: T) = wrap(scala.util.Success(value))
+}
+
+case class Try[T] private (val unwrap: STry[T]) {
+  import Try._
+  
+  def isFailure: Boolean = unwrap.isFailure
+  
+  def isSuccess: Boolean = unwrap.isSuccess
+  
+  def getOrElse(f: java.util.function.Supplier[_ <: T]): T = unwrap.getOrElse(f.get)
+  
+  def orElse(f: java.util.function.Supplier[Try[_ <: T]]): Try[T] = wrap(unwrap.orElse(f.get.unwrap))
+  
+  def get: T = unwrap.get
+  
+  def foreach(f: java.util.function.Consumer[T]): Unit = unwrap.foreach(f.accept)
+  
+  def flatMap[U](f: java.util.function.Function[T,Try[U]]): Try[U] = wrap(unwrap.flatMap(v => f.apply(v).unwrap))
+  
+  def map[U](f: java.util.function.Function[T,U]): Try[U] = wrap(unwrap.map(f.apply))
+  
+  def filter(p: java.util.function.Predicate[_ >: T]): Try[T] = wrap(unwrap.filter(p.test)) 
+  
+  def recover(pf: PartialFunction[Throwable,_ <: T]): Try[T] = wrap(unwrap.recover(pf))
+  
+  def recoverWith(pf: PartialFunction[Throwable,Try[_ <: T]]): Try[T] = wrap(unwrap.recoverWith(pf.andThen(_.unwrap)))
+  
+  def toOption: Option[T] = Option.wrap(unwrap.toOption)
+  
+  def failure: Try[Throwable] = wrap(unwrap.failed)
+  
+  def transform[U](successFunc: java.util.function.Function[T,Try[U]], 
+                   failureFunc: java.util.function.Function[Throwable,Try[U]]) = 
+     wrap(unwrap.transform(s => successFunc(s).unwrap, f => failureFunc(f).unwrap))
+}

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/concurrent/Concurrent.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/concurrent/Concurrent.scala
@@ -1,0 +1,8 @@
+package com.tradeshift.scalajapi.concurrent
+
+object Concurrent {
+  import scala.concurrent.{ blocking => scalaBlocking }
+  
+  def blocking[T](f: java.util.function.Supplier[T]): T = scalaBlocking { f.get }
+  def blocking(f: java.lang.Runnable): Unit = scalaBlocking { f.run }
+}

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/concurrent/Future.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/concurrent/Future.scala
@@ -11,13 +11,20 @@ import java.time.Instant
 import java.util.concurrent.TimeoutException
 
 object Future {
+  private implicit val ctx = ExecutionContext.global
+  
   def wrap[T](scalaFuture: concurrent.Future[T]): Future[T] = new Future(scalaFuture)
+  
+  def wrap[T](context: ExecutionContext, scalaFuture: concurrent.Future[T]): Future[T] = new Future(scalaFuture, context)
   
   def successful[T](value: T): Future[T] = wrap(concurrent.Future.successful(value))
   
   def failed[T](exception: Throwable): Future[T] = wrap(concurrent.Future.failed(exception))
 
-  def create[T](body: java.util.function.Supplier[T]): Future[T] = wrap(concurrent.Future(body.get))
+  def call[T](body: java.util.function.Supplier[T]): Future[T] = wrap(concurrent.Future(body.get))
+  
+  def call[T](context: ExecutionContext, body: java.util.function.Supplier[T]): Future[T] = 
+    wrap(context, concurrent.Future(body.get))
   
   def sequence[T](futures: java.lang.Iterable[Future[T]]): Future[JSeq[T]] = 
     wrap(concurrent.Future.sequence[T,collection.immutable.Seq](futures.asScala.toVector.map(_.unwrap)).map(JSeq.wrap))
@@ -27,13 +34,13 @@ object Future {
   
   def find[T](futures: java.lang.Iterable[Future[T]], p: java.util.function.Predicate[T]): Future[JOption[T]] =
     wrap(concurrent.Future.find(futures.asScala.toSeq.map(_.unwrap))(p.test).map(JOption.wrap))
-    
-  private implicit val ctx = ExecutionContext.global
 }
 
-case class Future[T] private (val unwrap: concurrent.Future[T]) {
-  import Future._
+case class Future[T] private (val unwrap: concurrent.Future[T], implicit val context: ExecutionContext = ExecutionContext.global) {
+  import Future.wrap
 
+  def on(ctx: ExecutionContext): Future[T] = copy(context = ctx)
+  
   def mapTo[T1](t: Class[T1]): Future[T1] = wrap(unwrap.mapTo[T1](ClassTag(t)))
   
   def map[T1](f: java.util.function.Function[T,T1]): Future[T1] = wrap(unwrap.map(f(_)))

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -2,7 +2,15 @@ name := "tests"
 
 EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
 
+EclipseKeys.executionEnvironment := Some(EclipseExecutionEnvironment.JavaSE18)
+
 libraryDependencies ++= Seq(
     "junit" % "junit" % "4.11" % "test",
-    "com.novocode" % "junit-interface" % "0.11" % "test"
+    "com.insightfullogic" % "lambda-behave" % "0.4" % "test",
+    "org.assertj" % "assertj-core" % "3.2.0" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % "test"    
 )
+
+// Ensure compilation with java 8
+javacOptions ++= Seq("-source", "1.8")
+javacOptions in (Compile, Keys.compile) ++= Seq("-target", "1.8", "-Xlint")

--- a/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
@@ -235,7 +235,7 @@ public class RouteTest extends RouteTestKit {
                 )
             ),
             path("notreally", () ->
-                rejectWith(new MissingFormFieldRejection("always failing"))
+                rejectWith(Rejections.missingFormField("always failing"))
             ),
             path("shouldnotfail", () ->
                 handleExceptions(xHandler, () ->

--- a/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
@@ -1,0 +1,288 @@
+package com.tradeshift.scalajapi.akka.route;
+
+import static com.tradeshift.scalajapi.akka.route.Directives.*;
+import static com.tradeshift.scalajapi.akka.route.StringUnmarshaller.*;
+
+import com.tradeshift.scalajapi.akka.route.Marshaller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+
+import org.junit.Test;
+
+import scala.concurrent.ExecutionContext;
+
+import com.tradeshift.scalajapi.collect.Seq;
+import com.tradeshift.scalajapi.concurrent.Future;
+
+import akka.http.javadsl.model.ContentType;
+import akka.http.javadsl.model.HttpCharsets;
+import akka.http.javadsl.model.HttpEntity;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.MediaRanges;
+import akka.http.javadsl.model.MediaType;
+import akka.http.javadsl.model.MediaTypes;
+import akka.http.javadsl.model.RequestEntity;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.Accept;
+import akka.http.javadsl.model.headers.RawHeader;
+import akka.http.scaladsl.server.MissingQueryParamRejection;
+import akka.http.scaladsl.server.MissingFormFieldRejection;
+import akka.http.scaladsl.server.Rejection;
+import akka.http.scaladsl.server.UnacceptedResponseContentTypeRejection;
+import akka.japi.pf.PFBuilder;
+import akka.util.ByteString;
+
+public class RouteTest extends RouteTestKit {
+    private final Route route = getRoute();
+    private static final Unmarshaller<String,BigDecimal> BIG_DECIMAL_PARAM = Unmarshaller.sync(s -> new BigDecimal(s));
+    
+    private final Unmarshaller<HttpRequest,BigDecimal> BIG_DECIMAL_BODY =
+        Unmarshaller.requestToEntity()
+                    .flatMap(Unmarshaller.entityToString(materializer()))
+                    .map(s -> new BigDecimal(s));
+    
+    private final Unmarshaller<HttpRequest,UUID> UUID_FROM_JSON_BODY =
+        Unmarshaller.requestToEntity()
+                    .flatMap(
+                        Unmarshaller.forMediaType(MediaTypes.APPLICATION_JSON,
+                        Unmarshaller.entityToString(materializer())))
+                    .map(s -> {
+                        // just a fake JSON parser, assuming it's {"id":"..."}
+                        Pattern regex = Pattern.compile("\"id\":\"(.+)\"");
+                        Matcher matcher = regex.matcher(s);
+                        matcher.find();
+                        return UUID.fromString(matcher.group(1));
+                    });
+    
+    private final Unmarshaller<HttpRequest,UUID> UUID_FROM_XML_BODY =
+        Unmarshaller.requestToEntity()
+                    .flatMap(
+                        Unmarshaller.forMediaTypes(Seq.of(MediaTypes.TEXT_XML, MediaTypes.APPLICATION_XML),
+                        Unmarshaller.entityToString(materializer())))
+                    .map(s -> {
+                        // just a fake XML parser, assuming it's <id>...</id>
+                        Pattern regex = Pattern.compile("<id>(.+)</id>");
+                        Matcher matcher = regex.matcher(s);
+                        matcher.find();
+                        return UUID.fromString(matcher.group(1));
+                    });
+    
+    private final Unmarshaller<HttpRequest,UUID> UUID_FROM_BODY = 
+        Unmarshaller.firstOf(UUID_FROM_JSON_BODY, UUID_FROM_XML_BODY);
+    
+    private final Marshaller<UUID, RequestEntity> UUID_TO_RQ = Marshaller.wrapEntity(
+        Marshaller.stringToEntity(), 
+        ContentType.create(MediaTypes.APPLICATION_JSON), 
+        (UUID u) -> "{\"id\":\"" + u + "\"}");
+    
+    private final Marshaller<UUID, HttpResponse> UUID_TO_JSON_BODY =
+        Marshaller.entityToResponse(
+        Marshaller.wrapEntity(Marshaller.stringToEntity(), ContentType.create(MediaTypes.APPLICATION_JSON), 
+            (UUID u) -> "{\"id\":\"" + u + "\"}"));
+    
+    private final Marshaller<UUID, HttpResponse> UUID_TO_XML_BODY(MediaType xmlType) { return
+        Marshaller.entityToResponse(
+        Marshaller.wrapEntity(Marshaller.byteStringToEntity(), ContentType.create(xmlType), 
+            (UUID u) -> ByteString.fromString("<id>" + u + "</id>")));
+    }
+    
+    private final Marshaller<UUID, HttpResponse> UUID_TO_BODY = Marshaller.oneOf(
+        UUID_TO_JSON_BODY,
+        UUID_TO_XML_BODY(MediaTypes.APPLICATION_XML),
+        UUID_TO_XML_BODY(MediaTypes.TEXT_XML));
+    
+    @Test
+    public void path_can_match_uuid() {
+        on(HttpRequest.GET("/documents/359e4920-a6a2-4614-9355-113165d600fb"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("document 359e4920-a6a2-4614-9355-113165d600fb");            
+        });
+    }
+    
+    @Test
+    public void path_can_match_element() {
+        on(HttpRequest.GET("/people/john"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("person john");            
+        });
+    }
+    
+    @Test
+    public void param_is_extracted() {
+        on(HttpRequest.GET("/cookies?amount=5"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("cookies 5");            
+        });
+    }
+    
+    @Test
+    public void required_param_causes_rejection_when_missing() {
+        on(HttpRequest.GET("/cookies"), route, () -> {
+            assertThat(rejections()).containsExactly(MissingQueryParamRejection.apply("amount"));            
+        });
+    }
+    
+    @Test
+    public void wrong_param_type_causes_next_route_to_be_evaluated() {
+        on(HttpRequest.GET("/cookies?amount=one"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("cookies (string) one");            
+        });
+    }
+    
+    @Test
+    public void required_param_causes_404_on_sealed_route() {
+        onSealed(HttpRequest.GET("/cookies"), route, () -> {
+            assertThat(status()).isEqualTo(StatusCodes.NOT_FOUND);
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("Request is missing required query parameter 'amount'");
+        });        
+    }
+    
+    @Test
+    public void custom_param_type_can_be_extracted() {
+        on(HttpRequest.GET("/cakes?amount=5"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("cakes 5");            
+        });
+    }
+    
+    @Test
+    public void custom_extractors_can_be_invoked() {
+        on(HttpRequest.GET("/bar").addHeader(RawHeader.create("foo", "hello")), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("bar hello");            
+        });        
+    }
+    
+    @Test
+    public void entity_can_be_unmarshalled() {
+        on(HttpRequest.POST("/bigdecimal").withEntity("1234"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("body 1234");            
+        });        
+    }
+    
+    @Test
+    public void entity_can_be_unmarshalled_when_picking_json_unmarshaller() {
+        on(HttpRequest.PUT("/uuid").withEntity(ContentType.create(MediaTypes.APPLICATION_JSON, HttpCharsets.UTF_8), 
+            "{\"id\":\"76b38659-1dec-4ee6-86d0-9ca787bf578c\"}"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("uuid 76b38659-1dec-4ee6-86d0-9ca787bf578c");            
+        });        
+    }
+    
+    @Test
+    public void entity_can_be_unmarshalled_when_picking_xml_unmarshaller() {
+        on(HttpRequest.PUT("/uuid").withEntity(ContentType.create(MediaTypes.APPLICATION_XML), 
+            "<id>76b38659-1dec-4ee6-86d0-9ca787bf578c</id>"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("uuid 76b38659-1dec-4ee6-86d0-9ca787bf578c");            
+        });        
+    }
+    
+    @Test
+    public void entity_can_be_marshalled_when_json_is_accepted() {
+        on(HttpRequest.GET("/uuid").addHeader(Accept.create(MediaRanges.create(MediaTypes.APPLICATION_JSON))), route, () -> {
+            assertThat(contentType().mediaType()).isEqualTo(MediaTypes.APPLICATION_JSON);
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("{\"id\":\"80a05eee-652e-4458-9bee-19b69dbe1dee\"}");            
+        });                
+    }
+    
+    @Test
+    public void entity_can_be_marshalled_when_xml_is_accepted() {
+        on(HttpRequest.GET("/uuid").addHeader(Accept.create(MediaRanges.create(MediaTypes.TEXT_XML))), route, () -> {
+            assertThat(contentType().mediaType()).isEqualTo(MediaTypes.TEXT_XML);
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("<id>80a05eee-652e-4458-9bee-19b69dbe1dee</id>");            
+        });                
+    }
+    
+    @Test
+    public void request_is_rejected_if_no_marshaller_fits_accepted_type() {
+        on(HttpRequest.GET("/uuid").addHeader(Accept.create(MediaRanges.create(MediaTypes.TEXT_PLAIN))), route, () -> {
+            assertThat(rejections()).hasSize(1);
+            Rejection rejection = rejections().get(0);
+            assertThat(rejection).isInstanceOf(UnacceptedResponseContentTypeRejection.class);
+        });                
+        
+    }
+    
+    @Test
+    public void exception_handlers_are_applied_even_if_the_route_throws_in_future() {
+        on(HttpRequest.GET("/shouldnotfail"), route, () -> {
+            assertThat(responseEntityStrict().data().utf8String()).isEqualTo("no problem!");            
+        });        
+    }
+    
+    private static ExceptionHandler xHandler = ExceptionHandler.of(
+        new PFBuilder<Throwable, Route>()
+        .match(IllegalArgumentException.class, x -> complete("no problem!"))
+        .build());
+    
+    private static Function<RequestContext,String> CUSTOM_EXTRACT = ctx -> ctx.getRequest().getHeader("foo").get().value();
+    
+    private Future<Integer> throwExceptionInFuture() {
+        return Future.<Integer>call(() -> { throw new IllegalArgumentException("always failing"); });
+    }
+    
+    public Route getRoute() {
+        return route(
+            path("documents", () ->
+                path(UUID(), id ->
+                    complete("document " + id)
+                )
+            ),
+            path("people", () ->
+                path(name ->
+                    complete("person " + name)
+                )
+            ),
+            path("notreally", () ->
+                rejectWith(new MissingFormFieldRejection("always failing"))
+            ),
+            path("shouldnotfail", () ->
+                handleExceptions(xHandler, () ->
+                    onSuccess(() -> throwExceptionInFuture(), value -> 
+                        complete("never reaches here")
+                    )
+                )
+            ),
+            path("cookies", () ->
+                param(INT(), "amount", amount -> 
+                    complete("cookies " + amount)
+                )
+            ),
+            path("cookies", () ->
+                param(STRING(), "amount", amount -> 
+                    complete("cookies (string) " + amount)
+                )
+            ),
+            path("bar", () ->
+                extract(CUSTOM_EXTRACT, value -> 
+                    complete("bar " + value)
+                )
+            ),
+            path("custom_response", () ->
+                complete(HttpResponse.create().withStatus(StatusCodes.ACCEPTED))
+            ),
+            path("bigdecimal", () ->
+                entityAs(BIG_DECIMAL_BODY, value -> 
+                    complete("body " + value)
+                )
+            ),
+            path("uuid", () -> route(
+                put(() ->
+                    entityAs(UUID_FROM_BODY, value -> 
+                        complete("uuid " + value)
+                    )
+                ),
+                get(() -> {
+                    UUID id = UUID.fromString("80a05eee-652e-4458-9bee-19b69dbe1dee");
+                    return complete(id, UUID_TO_BODY);
+                })
+            )),
+            path("cakes", () ->
+                param(BIG_DECIMAL_PARAM, "amount", amount -> 
+                    complete("cakes " + amount)
+                )
+            )
+        );
+    }
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/EitherTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/EitherTest.java
@@ -1,0 +1,17 @@
+package com.tradeshift.scalajapi.collect;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class EitherTest {
+    @Test
+    public void either_java_api_compiles() {
+        final Either<String,Integer> s = Left.of("s");
+        final Either<String,Integer> one = Right.of(1);
+        
+        assertEquals("left: s", s.fold(l -> "left: " + l, r -> "right: " + r));
+        assertEquals("right: 1", one.fold(l -> "left: " + l, r -> "right: " + r));
+        assertEquals("s", s.left().get());
+    }
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/concurrent/ConcurrentTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/concurrent/ConcurrentTest.java
@@ -1,0 +1,25 @@
+package com.tradeshift.scalajapi.concurrent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.Test;
+
+public class ConcurrentTest {
+    @Test
+    public void blocking_can_be_invoked_with_lambda_returning_value() {
+        int result = Concurrent.blocking(() -> 5);
+        assertEquals(5, result);
+    }
+    
+    @Test
+    public void blocking_can_be_invoked_with_Runnable_lambda() {
+        AtomicBoolean invoked = new AtomicBoolean(false);
+        Concurrent.blocking(() -> {
+            invoked.set(true);
+        });
+        assertTrue(invoked.get());
+    }
+}


### PR DESCRIPTION
This embraces Java 8 lambdas to do pretty much what you can do in the scala DSL: rejections, exceptions, marshalling, umarshalling, futures, with full interop and the ability to add "your own" of everything.

All scala DSL concept classes are classes in Java as well, except for `Directive`: directives are always plain static methods (i.e. methods on a scala `object`).
