### PR TITLE
Release 0.1-201511191609: Fix return type of java.lang.Iterable.iterator()

### DIFF
--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201511041419",
+    version := "0.1-201511191609",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
@@ -90,7 +90,7 @@ case class Map[K,V] private (val unwrap: immutable.Map[K,V]) extends java.lang.I
   
   def valuesToSeq: Seq[V] = Seq.wrap(unwrap.values.toVector)
   
-  override def iterator = new java.util.Iterator[(K,V)] {
+  override def iterator: java.util.Iterator[(K,V)] = new java.util.Iterator[(K,V)] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
@@ -82,7 +82,7 @@ case class Option[T] private (val unwrap: scala.Option[T]) extends java.lang.Ite
           Spliterators.spliterator(iterator, size, Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
   
-  override def iterator = new java.util.Iterator[T] {
+  override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
@@ -110,7 +110,7 @@ case class Seq[T] private (val unwrap: immutable.Seq[T]) extends java.lang.Itera
           Spliterators.spliterator(iterator, size, Spliterator.ORDERED | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
   
-  override def iterator = new java.util.Iterator[T] {
+  override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
@@ -66,7 +66,7 @@ case class Set[T] private (val unwrap: immutable.Set[T]) extends java.lang.Itera
           Spliterators.spliterator(iterator, size, Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
   
-  override def iterator = new java.util.Iterator[T] {
+  override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
@@ -72,7 +72,7 @@ case class SortedSet[T] private (val unwrap: immutable.SortedSet[T]) extends jav
           Spliterators.spliterator(iterator, size, Spliterator.ORDERED | Spliterator.DISTINCT | Spliterator.NONNULL | Spliterator.IMMUTABLE),
           false);
   
-  override def iterator = new java.util.Iterator[T] {
+  override def iterator: java.util.Iterator[T] = new java.util.Iterator[T] {
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next

--- a/tests/build.sbt
+++ b/tests/build.sbt
@@ -3,5 +3,6 @@ name := "tests"
 EclipseKeys.projectFlavor := EclipseProjectFlavor.Java
 
 libraryDependencies ++= Seq(
-    "junit" % "junit" % "4.11" % "test"
+    "junit" % "junit" % "4.11" % "test",
+    "com.novocode" % "junit-interface" % "0.11" % "test"
 )

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/MapTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/MapTest.java
@@ -1,0 +1,26 @@
+package com.tradeshift.scalajapi.collect;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import scala.Tuple2;
+import static org.junit.Assert.*;
+
+public class MapTest {
+    @Test
+    public void map_should_return_typesafe_iterator() {
+        Map<String,String> map = Map.of("hello", "world");
+        Iterator<Tuple2<String,String>> i = map.iterator();
+        assertTrue(i.hasNext());
+    }
+
+    @Test
+    public void seq_is_iterable() {
+        Map<String,String> map = Map.of("hello", "world");
+        for (Tuple2<String,String> s: map) {
+            assertEquals(Tuple2.apply("hello", "world"), s);
+        }
+    }
+    
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/OptionTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/OptionTest.java
@@ -1,0 +1,24 @@
+package com.tradeshift.scalajapi.collect;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class OptionTest {
+    @Test
+    public void option_should_return_typesafe_iterator() {
+        Option<String> option = Option.of("hello");
+        Iterator<String> i = option.iterator();
+        assertTrue(i.hasNext());
+    }
+
+    @Test
+    public void option_is_iterable() {
+        Option<String> option = Option.of("hello");
+        for (String s: option) {
+            assertEquals("hello", s);
+        }
+    }
+    
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/SeqTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/SeqTest.java
@@ -1,0 +1,24 @@
+package com.tradeshift.scalajapi.collect;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SeqTest {
+    @Test
+    public void seq_should_return_typesafe_iterator() {
+        Seq<String> seq = Seq.of("hello");
+        Iterator<String> i = seq.iterator();
+        assertTrue(i.hasNext());
+    }
+
+    @Test
+    public void seq_is_iterable() {
+        Seq<String> seq = Seq.of("hello");
+        for (String s: seq) {
+            assertEquals("hello", s);
+        }
+    }
+    
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/SetTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/SetTest.java
@@ -1,0 +1,24 @@
+package com.tradeshift.scalajapi.collect;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SetTest {
+    @Test
+    public void set_should_return_typesafe_iterator() {
+        Set<String> set = Set.of("hello");
+        Iterator<String> i = set.iterator();
+        assertTrue(i.hasNext());
+    }
+
+    @Test
+    public void set_is_iterable() {
+        Set<String> set = Set.of("hello");
+        for (String s: set) {
+            assertEquals("hello", s);
+        }
+    }
+    
+}

--- a/tests/src/test/java/com/tradeshift/scalajapi/collect/SortedSetTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/collect/SortedSetTest.java
@@ -1,0 +1,24 @@
+package com.tradeshift.scalajapi.collect;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SortedSetTest {
+    @Test
+    public void sorted_set_should_return_typesafe_iterator() {
+        SortedSet<String> set = SortedSet.of("hello");
+        Iterator<String> i = set.iterator();
+        assertTrue(i.hasNext());
+    }
+
+    @Test
+    public void sorted_set_is_iterable() {
+        SortedSet<String> set = SortedSet.of("hello");
+        for (String s: set) {
+            assertEquals("hello", s);
+        }
+    }
+    
+}


### PR DESCRIPTION
Apparently, scala compiles def A = new B() { ... } down to a method that
actually returns Object, not B. I have no idea how that would still
conform to the implemented interface, since it doesn't. This fix
gives the methods an explicit return type, so the poor Java compiler
can make sense of it.

@domask Please have a look. The version is already released onto Bintray.
