### PR TITLE
A few API additions

### DIFF
--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201512031534",
+    version := "0.1-201512091046",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Either.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Either.scala
@@ -27,6 +27,8 @@ object Either {
     def toOption: Option[L] = Option.wrap(unwrap.toOption)
     
     def toSeq: Seq[L] = Seq.wrap(unwrap.toSeq.toVector)
+    
+    override def toString: String = unwrap.toString    
   }
   
   case class RightProjection[L,R] private[collect] (unwrap: scala.util.Either.RightProjection[L,R]) {
@@ -53,6 +55,8 @@ object Either {
     def toOption: Option[R] = Option.wrap(unwrap.toOption)
     
     def toSeq: Seq[R] = Seq.wrap(unwrap.toSeq.toVector)
+    
+    override def toString: String = unwrap.toString
   }    
 }
 
@@ -77,5 +81,7 @@ case class Either[L,R] private (unwrap: scala.util.Either[L,R]) {
     unwrap.fold(fa.apply, fb.apply) 
     
   def swap: Either[R,L] = wrap(unwrap.swap)
+  
+  override def toString: String = unwrap.toString
 }
 

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
@@ -37,6 +37,8 @@ object Map {
 case class Map[K,V] private (val unwrap: immutable.Map[K,V]) extends java.lang.Iterable[(K,V)] {
   import Map._
   
+  def contains(key: K): Boolean = unwrap.contains(key)
+  
   def filter(p: java.util.function.BiPredicate[K,V]): Map[K,V] = wrap(unwrap.filter(e => p.test(e._1,e._2)))
   
   def size:Int = unwrap.size

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Map.scala
@@ -102,5 +102,7 @@ case class Map[K,V] private (val unwrap: immutable.Map[K,V]) extends java.lang.I
     val i = unwrap.iterator
     override def hasNext = i.hasNext
     override def next = i.next
-  }  
+  }
+  
+  override def toString: String = unwrap.toString  
 }

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Option.scala
@@ -93,4 +93,6 @@ case class Option[T] private (val unwrap: scala.Option[T]) extends java.lang.Ite
     override def hasNext = i.hasNext
     override def next = i.next
   }  
+  
+  override def toString: String = unwrap.toString
 }

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
@@ -48,6 +48,8 @@ object Seq {
 case class Seq[T] private (val unwrap: immutable.Seq[T]) extends java.lang.Iterable[T] {
   import Seq._
 
+  def contains(item: T): Boolean = unwrap.contains(item)
+  
   def filter(p: java.util.function.Predicate[T]): Seq[T] = wrap(unwrap.filter(p.test))
   
   def size:Int = unwrap.size

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Seq.scala
@@ -131,5 +131,7 @@ case class Seq[T] private (val unwrap: immutable.Seq[T]) extends java.lang.Itera
     override def hasNext = i.hasNext
     override def next = i.next
   }
+  
+  override def toString: String = unwrap.toString
 }
  

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
@@ -45,6 +45,8 @@ object Set {
 case class Set[T] private (val unwrap: immutable.Set[T]) extends java.lang.Iterable[T] {
   import Set._
   
+  def contains(item: T): Boolean = unwrap.contains(item)
+  
   def filter(p: java.util.function.Predicate[T]): Set[T] = wrap(unwrap.filter(p.test))
   
   def size:Int = unwrap.size

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Set.scala
@@ -88,4 +88,6 @@ case class Set[T] private (val unwrap: immutable.Set[T]) extends java.lang.Itera
     override def hasNext = i.hasNext
     override def next = i.next
   }
+  
+  override def toString: String = unwrap.toString
 }

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
@@ -94,4 +94,6 @@ case class SortedSet[T] private (val unwrap: immutable.SortedSet[T]) extends jav
     override def hasNext = i.hasNext
     override def next = i.next
   }
+
+  override def toString: String = unwrap.toString
 }

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/SortedSet.scala
@@ -49,6 +49,8 @@ object SortedSet {
 case class SortedSet[T] private (val unwrap: immutable.SortedSet[T]) extends java.lang.Iterable[T] {
   import SortedSet._
   
+  def contains(item: T): Boolean = unwrap.contains(item)
+  
   def filter(p: java.util.function.Predicate[T]): SortedSet[T] = wrap(unwrap.filter(p.test))
   
   def size:Int = unwrap.size

--- a/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Try.scala
+++ b/scalaLib/src/main/scala/com/tradeshift/scalajapi/collect/Try.scala
@@ -44,4 +44,6 @@ case class Try[T] private (val unwrap: STry[T]) {
   def transform[U](successFunc: java.util.function.Function[T,Try[U]], 
                    failureFunc: java.util.function.Function[Throwable,Try[U]]) = 
      wrap(unwrap.transform(s => successFunc(s).unwrap, f => failureFunc(f).unwrap))
+     
+  override def toString: String = unwrap.toString
 }


### PR DESCRIPTION
- `Set` wasn't so useful without `.contains()` (and, note, that indeed it's typesafe unlike Java's)
- Hide wrapper classes in debug output so `Set.of("foo").toString()` now actually is `"Set(foo)"`

@domask, a quick look?
