### PR TITLE
0.1-201603081300: Transition onComplete to CompletableFuture

### DIFF
--- a/akkaStreams/build.sbt
+++ b/akkaStreams/build.sbt
@@ -7,6 +7,7 @@ libraryDependencies ++= {
   Seq(
     "com.typesafe.akka" %% "akka-actor" % akkaVersion,
     "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
-    "com.typesafe.akka" %% "akka-http-experimental" % akkaStreamVersion
+    "com.typesafe.akka" %% "akka-http-experimental" % akkaStreamVersion,
+    "org.scala-lang.modules" %% "scala-java8-compat" % "0.7.0"
   )
 }

--- a/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/FutureDirectives.scala
+++ b/akkaStreams/src/main/scala/com/tradeshift/scalajapi/akka/route/FutureDirectives.scala
@@ -1,23 +1,34 @@
 package com.tradeshift.scalajapi.akka.route
 
-import java.util.function.Supplier
-import java.util.function.{Function => JFunction}
-import com.tradeshift.scalajapi.concurrent.Future
-import akka.http.scaladsl.server.directives.{FutureDirectives => D}
-import com.tradeshift.scalajapi.collect.Try
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CompletionStage
+import java.util.function.{ Function ⇒ JFunction }
 
+import java.util.function.Supplier
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext.Implicits.global // only to unwrap the CompletionException
+import scala.util.Try
+
+import akka.http.scaladsl.server.directives.{ FutureDirectives ⇒ D }
 
 trait FutureDirectives {
-  def onComplete[T](f: Supplier[Future[T]], inner: JFunction[Try[T], Route]) = ScalaRoute (
-    D.onComplete(f.get.unwrap) { value => 
-      inner.apply(Try.wrap(value)).toScala 
-    }
-  )
-  
-  def onSuccess[T](f: Supplier[Future[T]], inner: JFunction[T, Route]) = ScalaRoute (
-    D.onSuccess(f.get.unwrap) { value => 
-      inner.apply(value).toScala 
-    }
-  )
-  
+  def onComplete[T](f: Supplier[CompletionStage[T]], inner: JFunction[Try[T], Route]): Route = ScalaRoute(
+    D.onComplete(f.get.toScala.recover(unwrapCompletionException)) { value ⇒
+      inner.apply(value).toScala
+    })
+
+  def onSuccess[T](f: Supplier[CompletionStage[T]], inner: JFunction[T, Route]): Route = ScalaRoute(
+    D.onSuccess(f.get.toScala.recover(unwrapCompletionException)) { value ⇒
+      inner.apply(value).toScala
+    })
+
+  // This might need to be raised as an issue to scala-java8-compat instead.
+  // Right now, having this in Java:
+  //     CompletableFuture.supplyAsync(() -> { throw new IllegalArgumentException("always failing"); })
+  // will in fact fail the future with CompletionException.
+  private def unwrapCompletionException[T]: PartialFunction[Throwable, T] = {
+    case x: CompletionException if x.getCause ne null ⇒
+      throw x.getCause
+  }
 }

--- a/project/ScalaJApi.scala
+++ b/project/ScalaJApi.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbteclipse.plugin.EclipsePlugin._
 object ScalaJApi extends Build {
   lazy val commonSettings = Seq(
     organization := "com.tradeshift.scala-japi",
-    version := "0.1-201602171211",
+    version := "0.1-201603081300",
     scalaVersion := "2.11.7",
     scalacOptions ++= "-deprecation" :: "-feature" :: "-target:jvm-1.8" :: Nil,
     licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT"))),

--- a/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
+++ b/tests/src/test/java/com/tradeshift/scalajapi/akka/route/RouteTest.java
@@ -9,6 +9,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
@@ -304,8 +306,8 @@ public class RouteTest extends RouteTestKit {
     
     private static Function<RequestContext,String> CUSTOM_EXTRACT = ctx -> ctx.getRequest().getHeader("foo").get().value();
     
-    private Future<Integer> throwExceptionInFuture() {
-        return Future.<Integer>call(() -> { throw new IllegalArgumentException("always failing"); });
+    private CompletionStage<Integer> throwExceptionInFuture() {
+        return CompletableFuture.<Integer>supplyAsync(() -> { throw new IllegalArgumentException("always failing"); });
     }
     
     public Route getRoute() {


### PR DESCRIPTION
This aligns with the direction of the real akka Java DSL, and also happens
to allow us to fix the wrapping of CompletionException.

@domask 
